### PR TITLE
fix a few bugs related to mempool & buffer

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -60,6 +60,7 @@ func (b *Buffer) grows(n int) (i int) {
 		copy(mem.Data, b.Data)
 		b.pool.Free(b.mem)
 		b.mem = mem
+		return
 	}
 
 	data := make([]byte, newLen, cap(b.Data)/4+newLen)

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -12,6 +12,13 @@ func Test_Buffer(t *testing.T) {
 	VerifyBuffer(t, buffer)
 }
 
+func Test_PoolBuffer(t *testing.T) {
+	pool := NewMemPool(10, 1, 10)
+	buffer := NewPoolBuffer(0, 0, pool)
+	PrepareBuffer(buffer)
+	VerifyBuffer(t, buffer)
+}
+
 func PrepareBuffer(buffer *Buffer) {
 	buffer.WriteVarint(0x12345678AABBCCDD)
 	buffer.WriteUvarint(0x12345678AABBCCDD)
@@ -36,6 +43,7 @@ func PrepareBuffer(buffer *Buffer) {
 	buffer.WriteFloat64BE(99.02)
 	buffer.WriteString("Hello1")
 	buffer.WriteBytes([]byte("Hello2"))
+	buffer.WriteBytes(bytes.Repeat([]byte("l"), 4096))
 
 	buffer.WriteRune('好')
 }
@@ -64,6 +72,7 @@ func VerifyBuffer(t *testing.T, buffer *Buffer) {
 	unitest.Pass(t, buffer.ReadFloat64BE() == 99.02)
 	unitest.Pass(t, buffer.ReadString(6) == "Hello1")
 	unitest.Pass(t, bytes.Equal(buffer.ReadBytes(6), []byte("Hello2")))
+	unitest.Pass(t, bytes.Equal(buffer.ReadBytes(4096), bytes.Repeat([]byte("l"), 4096)))
 
 	r, _, _ := buffer.ReadRune()
 	unitest.Pass(t, r == '好')

--- a/pool.go
+++ b/pool.go
@@ -40,6 +40,8 @@ func (pool *MemPool) Alloc(size, capacity int) *mem {
 		}
 		m := pool.classes[(capacity-pool.off)/1024].Pop()
 		if m != nil {
+			// reset its length to given size
+			m.Data = m.Data[:size]
 			return m
 		}
 	}


### PR DESCRIPTION
1. Buffer.grows should return when allocated memory from pool
2. MemPool.Alloc should reset slice's length to given size if slice is
from pool