### PR TITLE
修复Manager关闭过程中添加Session可能导致关闭过程提前结束的问题

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.7
+  - 1.12.7
 
 install:
     - go get -t -v ./...

--- a/manager.go
+++ b/manager.go
@@ -75,6 +75,8 @@ func (manager *Manager) delSession(session *Session) {
 	smap.Lock()
 	defer smap.Unlock()
 
-	delete(smap.sessions, session.id)
-	manager.disposeWait.Done()
+	if _, ok := smap.sessions[session.id]; ok {
+		delete(smap.sessions, session.id)
+		manager.disposeWait.Done()
+	}
 }


### PR DESCRIPTION
修复Manager关闭过程中，添加Session会触发session.Close()，但是session并没有添加到map中，disopseWait也未增加，这时session.Close触发delSession会导致关闭过程提前结束。